### PR TITLE
Fix to critical duplicate Babel plugin bug

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,7 +12,6 @@ module.exports = {
     ['@babel/plugin-proposal-private-methods', { loose: true }],
     ['@babel/plugin-proposal-private-property-in-object', { loose: true }],
     ['@babel/plugin-proposal-class-properties', { loose: true }],
-    ['@babel/plugin-proposal-private-methods', { loose: true }],
     [
       'module-resolver',
       {


### PR DESCRIPTION
## What?
I have removed a duplicate `@babel/plugin-proposal-private-methods` in the `babel.config.js` file. See ticket #3.

## Why?
I was getting a critical error, failing in the Babel compilation stage of the application, and it stated that it was because duplicate plugins were being defined.

## How

I decided to just remove the duplicate plugin, however, it is unclear if the inclusion of this was on purpose. Babel does suggest that you can use two instances of a plugin, but give the duplicate a unique name. But given the severity of this bug, removing it seems to be the best option.

## Bug Reference
```
Error: Duplicate plugin/preset detected.
If you'd like to use two separate instances of a plugin,
they need separate names, e.g.

  plugins: [
    ['some-plugin', {}],
    ['some-plugin', {}, 'some unique name'],
  ]

Duplicates detected are:
[
  {
    "alias": "/Users/chris/Code/Codeless-Builder/node_modules/@babel/plugin-proposal-private-methods/lib/index.js",
    "options": {
      "loose": true
    },
    "dirname": "/Users/chris/Code/Codeless-Builder",
    "ownPass": false,
    "file": {
      "request": "@babel/plugin-proposal-private-methods",
      "resolved": "/Users/chris/Code/Codeless-Builder/node_modules/@babel/plugin-proposal-private-methods/lib/index.js"
    }
  },
  {
    "alias": "/Users/chris/Code/Codeless-Builder/node_modules/@babel/plugin-proposal-private-methods/lib/index.js",
    "options": {
      "loose": true
    },
    "dirname": "/Users/chris/Code/Codeless-Builder",
    "ownPass": false,
    "file": {
      "request": "@babel/plugin-proposal-private-methods",
      "resolved": "/Users/chris/Code/Codeless-Builder/node_modules/@babel/plugin-proposal-private-methods/lib/index.js"
    }
  }
]
    at createDescriptors.next (<anonymous>)
    at createPluginDescriptors.next (<anonymous>)
    at plugins.next (<anonymous>)
    at mergeChainOpts.next (<anonymous>)
    ```